### PR TITLE
Rework server info row updates

### DIFF
--- a/connection/libvirt/src/connection/mod.rs
+++ b/connection/libvirt/src/connection/mod.rs
@@ -30,7 +30,7 @@ use futures::future::LocalBoxFuture;
 use futures::{StreamExt, TryStreamExt, stream};
 use gettextrs::gettext;
 use indexmap::IndexMap;
-use log::{debug, error, warn};
+use log::{debug, error, trace, warn};
 use virt::connect::Connect;
 use virt::domain::Domain;
 use virt::sys::{
@@ -491,6 +491,7 @@ impl LoadCacheObject for LibVirtServerState {
         Self: Sized,
     {
         let (domain, domain_name, hostname) = params;
+        trace!("libvirt: updating state for {domain_name} @ {hostname}");
         let is_active = domain.is_active().ok();
         let is_paused = domain
             .get_state()

--- a/lib/src/cache.rs
+++ b/lib/src/cache.rs
@@ -62,7 +62,7 @@ where
                 CacheRefHolder(self.value.read().await)
             }
             Some((cur_time, _v)) => {
-                if cur_time.add(self.valid_for) > Instant::now() {
+                if cur_time.add(self.valid_for) <= Instant::now() {
                     let mut write_time_and_v =
                         RwLockUpgradableReadGuard::upgrade(cur_time_and_v).await;
                     let old_value = write_time_and_v.take().unwrap().1;

--- a/po/POTFILES
+++ b/po/POTFILES
@@ -105,9 +105,9 @@ src/widget/connection_list/connection_stack.rs
 src/widget/connection_list/info_page.blp
 src/widget/connection_list/info_page.rs
 src/widget/connection_list/mod.rs
+src/widget/connection_list/server_actions.rs
 src/widget/connection_list/server_group.blp
 src/widget/connection_list/server_group.rs
-src/widget/connection_list/server_info.rs
 src/widget/connection_list/server_info/icon.blp
 src/widget/connection_list/server_info/icon.rs
 src/widget/connection_list/server_row.rs

--- a/src/widget/connection_list/info_page.blp
+++ b/src/widget/connection_list/info_page.blp
@@ -23,7 +23,7 @@ template $FieldMonitorConnectionInfoPage: Adw.Bin {
             }
 
             [end]
-            Box box_for_connection_action {}
+            Adw.Bin bin_for_connection_action {}
         }
 
         content: Stack status_stack {

--- a/src/widget/connection_list/info_page.rs
+++ b/src/widget/connection_list/info_page.rs
@@ -16,9 +16,8 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 use crate::application::FieldMonitorApplication;
-use crate::widget::connection_list::ServerOrConnection;
+use crate::widget::connection_list::server_actions::FieldMonitorServerActions;
 use crate::widget::connection_list::server_group::FieldMonitorServerGroup;
-use crate::widget::connection_list::server_info::maybe_add_actions_button;
 use crate::widget::connection_list::server_row::FieldMonitorServerRow;
 use adw::prelude::*;
 use adw::subclass::prelude::*;
@@ -50,7 +49,7 @@ mod imp {
         #[template_child]
         pub group_box: TemplateChild<gtk::Box>,
         #[template_child]
-        pub box_for_connection_action: TemplateChild<gtk::Box>,
+        pub bin_for_connection_action: TemplateChild<adw::Bin>,
         #[property(get, set)]
         pub connection: RefCell<Option<ConnectionInstance>>,
         #[property(get, set)]
@@ -109,12 +108,9 @@ impl FieldMonitorConnectionInfoPage {
             #[strong]
             connection,
             async move {
-                maybe_add_actions_button(
-                    &slf.imp().box_for_connection_action,
-                    ServerOrConnection::Connection(&connection),
-                    &connection.connection_id(),
-                )
-                .await;
+                slf.imp().bin_for_connection_action.set_child(Some(
+                    &FieldMonitorServerActions::new_for_connection(&connection).await,
+                ));
             }
         ));
 

--- a/src/widget/connection_list/mod.rs
+++ b/src/widget/connection_list/mod.rs
@@ -20,6 +20,7 @@ pub const DEFAULT_GENERIC_ICON: &str = "network-server-symbolic";
 mod connection_list_navbar;
 mod connection_stack;
 mod info_page;
+pub mod server_actions;
 mod server_group;
 mod server_info;
 mod server_row;
@@ -28,7 +29,7 @@ pub use connection_list_navbar::*;
 pub use connection_stack::*;
 use libfieldmonitor::connection::*;
 
-enum ServerOrConnection<'a> {
+pub enum ServerOrConnection<'a> {
     Server(&'a dyn ServerConnection),
     Connection(&'a dyn Connection),
 }

--- a/src/widget/connection_list/server_actions.rs
+++ b/src/widget/connection_list/server_actions.rs
@@ -1,0 +1,362 @@
+/* Copyright 2024-2026 Marco Köpcke
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+use crate::widget::connection_list::ServerOrConnection;
+use crate::widget::connection_list::server_info::ServerInfoWidget;
+use adw::gio;
+use adw::prelude::{ActionRowExt, BinExt};
+use gettextrs::gettext;
+use glib::{Object, WeakRef};
+use gtk::glib;
+use gtk::prelude::*;
+use gtk::subclass::prelude::*;
+use libfieldmonitor::connection::*;
+use libfieldmonitor::i18n::gettext_f;
+use log::debug;
+use std::borrow::Cow;
+use std::cell::Cell;
+use std::hash::{DefaultHasher, Hash, Hasher};
+
+#[derive(Clone, Copy, Debug)]
+enum ButtonSlot {
+    Edit = 0,
+    Connect = 1,
+    Actions = 2,
+}
+
+mod imp {
+    use super::*;
+
+    #[derive(Debug, Default)]
+    pub struct FieldMonitorServerActions {
+        pub edit_button: WeakRef<gtk::Widget>,
+        pub connect_button: WeakRef<gtk::Widget>,
+        pub actions_button: WeakRef<gtk::Widget>,
+        pub last_state_editable: Cell<bool>,
+        // length, hash of the vec
+        pub last_state_adapters: Cell<(usize, u64)>,
+        // length, hash of the vec
+        pub last_state_actions: Cell<(usize, u64)>,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for FieldMonitorServerActions {
+        const NAME: &'static str = "FieldMonitorServerActions";
+        type Type = super::FieldMonitorServerActions;
+        type ParentType = gtk::Box;
+    }
+
+    impl ObjectImpl for FieldMonitorServerActions {}
+    impl WidgetImpl for FieldMonitorServerActions {}
+    impl BoxImpl for FieldMonitorServerActions {}
+}
+
+glib::wrapper! {
+    pub struct FieldMonitorServerActions(ObjectSubclass<imp::FieldMonitorServerActions>)
+        @extends gtk::Widget, gtk::Box,
+        @implements gtk::ConstraintTarget, gtk::Buildable, gtk::Accessible;
+}
+
+impl FieldMonitorServerActions {
+    /// Updates the server connect/edit/actions buttons.
+    /// This will add a FieldMonitorServerActions to the widget if it doesn't already have one.
+    pub async fn update_server_info_widget(
+        widget: &impl ServerInfoWidget,
+        server: &dyn ServerConnection,
+        path: &str,
+    ) {
+        let act_bin = widget.get_actions_container();
+        let slf = act_bin.child().and_downcast::<Self>().unwrap_or_else(|| {
+            let slf = Self::new();
+            act_bin.set_child(Some(&slf));
+            slf
+        });
+
+        slf.process_edit_button(server, path).await;
+        slf.process_connect_button(widget.get_row(), server, path)
+            .await;
+        slf.process_action_buttons(ServerOrConnection::Server(server), path)
+            .await;
+    }
+
+    /// Create an instance for a connection to be placed on a connection info page (for
+    /// connection actions).
+    pub async fn new_for_connection(connection: &ConnectionInstance) -> Self {
+        let slf = Self::new();
+        slf.process_action_buttons(
+            ServerOrConnection::Connection(connection),
+            &connection.connection_id(),
+        )
+        .await;
+        slf
+    }
+
+    fn new() -> Self {
+        Object::builder()
+            .property("spacing", 6)
+            .property("orientation", gtk::Orientation::Horizontal)
+            .build()
+    }
+
+    /// Adds, updates, or removes the edit button if `editable` has changed since
+    /// the last time this was called.
+    async fn process_edit_button(&self, server: &dyn ServerConnection, path: &str) {
+        let imp = self.imp();
+        let last_state_editable = imp.last_state_editable.get();
+        let current_editable = server.editable();
+        imp.last_state_editable.set(current_editable);
+        if !last_state_editable && current_editable {
+            debug!("{path}: adding edit button for server");
+            let label = gettext("Edit Server");
+            let button = gtk::Button::builder()
+                .action_name("app.edit-connection-server")
+                .action_target(&path.to_variant())
+                .icon_name("edit-symbolic")
+                .tooltip_text(&label)
+                .valign(gtk::Align::Center)
+                .css_classes(["flat"])
+                .build();
+            button.update_property(&[gtk::accessible::Property::Label(&label)]);
+
+            self.set_slot(ButtonSlot::Edit, Some(button.upcast_ref()));
+        } else if last_state_editable && !current_editable {
+            debug!("{path}: removing edit button for server");
+            self.set_slot(ButtonSlot::Edit, None);
+        }
+    }
+
+    /// Adds, updates, or removes the connect button if the supported adapters have changed since
+    /// the last time this was called.
+    async fn process_connect_button(
+        &self,
+        row: Option<&impl IsA<adw::ActionRow>>,
+        server: &dyn ServerConnection,
+        path: &str,
+    ) {
+        let imp = self.imp();
+        let (last_len, last_hash) = imp.last_state_adapters.get();
+        let adapters = server.supported_adapters().await;
+        let new_len = adapters.len();
+        if new_len == 0 && last_len == new_len {
+            return;
+        }
+        let new_hash = hash(&adapters);
+        if last_hash == new_hash {
+            return;
+        }
+        imp.last_state_adapters.set((new_len, new_hash));
+        debug!("{path}: updating connect button for server");
+
+        let connect_button = if adapters.len() == 1 {
+            let adapter = adapters.into_iter().next().unwrap();
+            Some(make_single_connect_button(path, adapter))
+        } else if !adapters.is_empty() {
+            Some(make_multi_connection_button(path, adapters))
+        } else {
+            None
+        };
+
+        if let Some(row) = row {
+            let row = row.upcast_ref();
+            row.set_activatable_widget(connect_button.as_ref());
+            row.set_activatable(connect_button.is_some());
+        }
+
+        self.set_slot(ButtonSlot::Connect, connect_button.as_ref());
+    }
+
+    /// Adds, updates, or removes the actions button if the supported actions have changed since
+    /// the last time this was called.
+    pub async fn process_action_buttons(
+        &self,
+        server_or_connection: ServerOrConnection<'_>,
+        path: &str,
+    ) {
+        let imp = self.imp();
+        let (last_len, last_hash) = imp.last_state_actions.get();
+        let (actions, is_server) = match server_or_connection {
+            ServerOrConnection::Server(server) => (server.actions().await, true),
+            ServerOrConnection::Connection(connection) => (connection.actions().await, false),
+        };
+        let new_len = actions.len();
+        if new_len == 0 && last_len == new_len {
+            return;
+        }
+        let new_hash = hash(&actions);
+        if last_hash == new_hash {
+            return;
+        }
+        imp.last_state_actions.set((new_len, new_hash));
+        debug!("{path}: updating action button for connection/server");
+
+        if actions.is_empty() {
+            self.set_slot(ButtonSlot::Actions, None);
+            return;
+        }
+
+        let menu = gio::Menu::new();
+        for (action_id, action_title) in actions {
+            let action_target = (is_server, path, &*action_id).to_variant();
+            menu.append(
+                Some(&*action_title),
+                Some(
+                    gio::Action::print_detailed_name(
+                        "app.perform-connection-action",
+                        Some(&action_target),
+                    )
+                    .as_str(),
+                ),
+            );
+        }
+
+        let label = gettext("Actions");
+        let button = gtk::MenuButton::builder()
+            .menu_model(&menu)
+            .icon_name("view-more-symbolic")
+            .tooltip_text(&label)
+            .valign(gtk::Align::Center)
+            .css_classes(["flat"])
+            .build();
+        button.update_property(&[gtk::accessible::Property::Label(&label)]);
+
+        self.set_slot(ButtonSlot::Actions, Some(button.upcast_ref()));
+    }
+
+    fn set_slot(&self, pos: ButtonSlot, new_value: Option<&gtk::Widget>) {
+        let imp = self.imp();
+        let slot = match pos {
+            ButtonSlot::Edit => &imp.edit_button,
+            ButtonSlot::Connect => &imp.connect_button,
+            ButtonSlot::Actions => &imp.actions_button,
+        };
+        match (new_value, slot.upgrade()) {
+            (Some(v), None) => {
+                insert_into_box(self.upcast_ref(), self.occupied_slots_before(pos), v);
+                slot.set(Some(v));
+            }
+            (Some(v), Some(old)) => {
+                replace_in_box(self.upcast_ref(), &old, Some(v));
+                slot.set(Some(v));
+            }
+            (None, Some(old)) => {
+                replace_in_box(self.upcast_ref(), &old, None);
+                slot.set(None);
+            }
+            (None, None) => {}
+        }
+    }
+
+    /// Number of slots that come before `pos` in display order and currently have a widget
+    /// present in the box.
+    fn occupied_slots_before(&self, pos: ButtonSlot) -> usize {
+        let imp = self.imp();
+        [
+            (ButtonSlot::Edit, &imp.edit_button),
+            (ButtonSlot::Connect, &imp.connect_button),
+            (ButtonSlot::Actions, &imp.actions_button),
+        ]
+        .into_iter()
+        .filter(|(slot, weak)| (*slot as usize) < pos as usize && weak.upgrade().is_some())
+        .count()
+    }
+}
+
+/// Insert a widget at the given index in the box. If the index is equal to or bigger than the
+/// number of children in the box, it will be inserted at the end.
+fn insert_into_box(boxx: &gtk::Box, index: usize, widget: &gtk::Widget) {
+    let sibling = if index == 0 {
+        None
+    } else {
+        nth_child(boxx, index - 1).or_else(|| boxx.last_child())
+    };
+    boxx.insert_child_after(widget, sibling.as_ref());
+}
+
+/// Replace `old` in `boxx` with `new`. If `new` is `None` `old` is just removed.
+fn replace_in_box(boxx: &gtk::Box, old: &gtk::Widget, new: Option<&gtk::Widget>) {
+    if let Some(new) = new {
+        boxx.insert_child_after(new, old.prev_sibling().as_ref());
+    }
+    boxx.remove(old);
+}
+
+/// Returns the `n`-th (0-based) child of `boxx`, if it has that many children.
+fn nth_child(boxx: &gtk::Box, n: usize) -> Option<gtk::Widget> {
+    let mut child = boxx.first_child();
+    let mut i = 0;
+    while let Some(c) = child {
+        if i == n {
+            return Some(c);
+        }
+        child = c.next_sibling();
+        i += 1;
+    }
+    None
+}
+
+fn make_multi_connection_button(path: &str, adapters: Vec<(Cow<str>, Cow<str>)>) -> gtk::Widget {
+    let menu = gio::Menu::new();
+    for (adapter_id, adapter_label) in adapters {
+        let action_target = (path, &*adapter_id).to_variant();
+        menu.append(
+            Some(&*adapter_label),
+            Some(
+                gio::Action::print_detailed_name("app.connect-to-server", Some(&action_target))
+                    .as_str(),
+            ),
+        );
+    }
+
+    let label = gettext("Connect");
+    let button = gtk::MenuButton::builder()
+        .menu_model(&menu)
+        .icon_name("display-with-window-symbolic")
+        .tooltip_text(&label)
+        .valign(gtk::Align::Center)
+        .css_classes(["flat"])
+        .build();
+    button.update_property(&[gtk::accessible::Property::Label(&label)]);
+    button.upcast()
+}
+
+fn make_single_connect_button(
+    path: &str,
+    (adapter_id, adapter_label): (Cow<str>, Cow<str>),
+) -> gtk::Widget {
+    let label = gettext_f(
+        // Translators: Do NOT translate the content between '{' and '}', this is a
+        // variable name.
+        "Connect via {adapter}",
+        &[("adapter", &adapter_label)],
+    );
+    let button = gtk::Button::builder()
+        .action_name("app.connect-to-server")
+        .action_target(&(path, &*adapter_id).to_variant())
+        .icon_name("display-with-window-symbolic")
+        .tooltip_text(&label)
+        .valign(gtk::Align::Center)
+        .css_classes(["flat"])
+        .build();
+    button.update_property(&[gtk::accessible::Property::Label(&label)]);
+    button.upcast()
+}
+
+fn hash<T: Hash>(t: &T) -> u64 {
+    let mut s = DefaultHasher::new();
+    t.hash(&mut s);
+    s.finish()
+}

--- a/src/widget/connection_list/server_group.rs
+++ b/src/widget/connection_list/server_group.rs
@@ -19,6 +19,7 @@ use crate::application::FieldMonitorApplication;
 use crate::widget::connection_list::server_info::{
     ServerInfoIcon, ServerInfoUpdater, ServerInfoWidget,
 };
+use crate::widget::window::FieldMonitorWindow;
 use adw::prelude::*;
 use adw::subclass::prelude::*;
 use glib::object::ObjectExt;
@@ -101,6 +102,10 @@ impl FieldMonitorServerGroup {
 }
 
 impl ServerInfoWidget for FieldMonitorServerGroup {
+    fn window(&self) -> Option<FieldMonitorWindow> {
+        self.root().and_downcast()
+    }
+
     fn set_server_title(&self, title: &str) {
         FieldMonitorServerGroup::set_server_title(self, title)
     }

--- a/src/widget/connection_list/server_info.rs
+++ b/src/widget/connection_list/server_info.rs
@@ -21,18 +21,18 @@
 mod icon;
 
 pub use self::icon::ServerInfoIcon;
+use crate::widget::connection_list::DEFAULT_GENERIC_ICON;
+use crate::widget::connection_list::server_actions::FieldMonitorServerActions;
 use crate::widget::connection_list::server_info::icon::IsOnline;
-use crate::widget::connection_list::{DEFAULT_GENERIC_ICON, ServerOrConnection};
+use crate::widget::window::FieldMonitorWindow;
 use adw::prelude::*;
 use futures::future::LocalBoxFuture;
-use gettextrs::gettext;
 use glib::object::{Cast, IsA, ObjectType};
 use glib::{ControlFlow, WeakRef, timeout_future};
-use gtk::gio;
 use libfieldmonitor::connection::{IconSpec, ServerConnection, ServerMetadata};
-use libfieldmonitor::i18n::gettext_f;
-use std::borrow::Cow;
+use log::trace;
 use std::rc::Rc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 pub struct ServerInfoUpdater<T>
@@ -56,71 +56,87 @@ where
             full_path,
         };
 
-        slf.run_updater(Self::update_metadata, Duration::from_secs(3));
-        slf.run_updater(Self::update_actions, Duration::from_secs(45));
+        slf.run_updater(Self::update_server_info, Duration::from_secs(3));
     }
 
-    fn update_metadata(
+    fn update_server_info(
         target: T,
         server: Rc<Box<dyn ServerConnection>>,
         path: Rc<Vec<String>>,
-    ) -> LocalBoxFuture<'static, ()> {
+        call_count: u64,
+    ) -> LocalBoxFuture<'static, bool> {
+        // TODO: Ideally we really shouldn't spawn a future per row, but instead have one
+        //       update loop for all rows, where we also only check once if the list is visible.
         Box::pin(async move {
-            let metadata = server.metadata().await;
-            target.set_server_title(&metadata.title);
-            target.set_server_subtitle(metadata.subtitle.as_deref());
-
-            let container = target.get_icon_container();
-            let new_status = match metadata.is_online {
-                Some(true) => IsOnline::Online,
-                Some(false) => IsOnline::Offline,
-                None => IsOnline::Unknown,
-            };
-
-            // If the online status changed, we should also update the actions
-            let old_status = container.status();
-            if old_status != IsOnline::Unknown
-                && new_status != IsOnline::Unknown
-                && old_status != new_status
+            let window = target.window();
+            if window
+                .as_ref()
+                .map(FieldMonitorWindow::is_connection_list_visible)
+                .unwrap_or_default()
             {
-                glib::spawn_future_local(Self::update_actions(target.clone(), server, path));
+                let metadata = server.metadata().await;
+                let container = target.get_icon_container();
+
+                // -- every three seconds
+                // Check online status
+                let new_status = match metadata.is_online {
+                    Some(true) => IsOnline::Online,
+                    Some(false) => IsOnline::Offline,
+                    None => IsOnline::Unknown,
+                };
+                let old_status = container.status();
+                let online_status_changed = old_status != IsOnline::Unknown
+                    && new_status != IsOnline::Unknown
+                    && old_status != new_status;
+                if online_status_changed {
+                    trace!("{}: online status changed", path.join("/"));
+                }
+
+                if call_count.is_multiple_of(40) {
+                    // -- every two minutes
+                    trace!("{}: update icon", path.join("/"));
+                    Self::update_icon(&target, new_status, &metadata);
+                }
+                if call_count.is_multiple_of(20) {
+                    // -- once per minute
+                    trace!("{}: update title & subtitle", path.join("/"));
+                    target.set_server_title(&metadata.title);
+                    target.set_server_subtitle(metadata.subtitle.as_deref());
+                }
+                if online_status_changed || call_count.is_multiple_of(15) {
+                    // -- every 45 seconds or if online status changed
+                    let path = path.join("/");
+                    trace!("{}: update buttons", path);
+                    FieldMonitorServerActions::update_server_info_widget(&target, &**server, &path)
+                        .await;
+                    trace!("{}: update icon status", path);
+                    container.set_status(new_status);
+                }
+                true
+            } else {
+                // to limit performance impact while connection view is active: delay next update
+                timeout_future(Duration::from_secs(10)).await;
+                false
             }
-
-            Self::update_icon(&target, new_status, metadata);
-        })
-    }
-
-    fn update_actions(
-        target: T,
-        server: Rc<Box<dyn ServerConnection>>,
-        path: Rc<Vec<String>>,
-    ) -> LocalBoxFuture<'static, ()> {
-        Box::pin(async move {
-            let path = path.join("/");
-
-            let suffix = gtk::Box::builder()
-                .spacing(6)
-                .orientation(gtk::Orientation::Horizontal)
-                .build();
-
-            Self::maybe_add_edit_button(&suffix, &**server, &path).await;
-            Self::maybe_add_connect_button(target.get_row(), &suffix, &**server, &path).await;
-            maybe_add_actions_button(&suffix, ServerOrConnection::Server(&**server), &path).await;
-
-            target.get_actions_container().set_child(Some(&suffix));
         })
     }
 
     /// Run the update function in a regular interval until the target widget stops to exist.
     fn run_updater<F>(&self, cb: F, duration: Duration)
     where
-        F: Fn(T, Rc<Box<dyn ServerConnection>>, Rc<Vec<String>>) -> LocalBoxFuture<'static, ()>
+        F: Fn(
+                T,
+                Rc<Box<dyn ServerConnection>>,
+                Rc<Vec<String>>,
+                u64,
+            ) -> LocalBoxFuture<'static, bool>
             + 'static,
     {
         let mut flow = ControlFlow::Continue;
         let target = self.target.clone();
         let server = self.server.clone();
         let full_path = self.full_path.clone();
+        let update_call_count = AtomicU64::new(0);
 
         glib::spawn_future_local(async move {
             while flow == ControlFlow::Continue {
@@ -129,7 +145,20 @@ where
                         flow = ControlFlow::Break;
                     }
                     Some(target) => {
-                        cb(target, server.clone(), full_path.clone()).await;
+                        let cb_result = cb(
+                            target,
+                            server.clone(),
+                            full_path.clone(),
+                            update_call_count.load(Ordering::Relaxed),
+                        )
+                        .await;
+                        if cb_result {
+                            update_call_count.fetch_add(1, Ordering::Relaxed);
+                        } else {
+                            // if we didn't run an update we reset the counter, to cause a full update
+                            // next time
+                            update_call_count.store(0, Ordering::Relaxed);
+                        }
                         timeout_future(duration).await;
                     }
                 }
@@ -137,7 +166,7 @@ where
         });
     }
 
-    fn update_icon(target: &T, status: IsOnline, metadata: ServerMetadata) {
+    fn update_icon(target: &T, status: IsOnline, metadata: &ServerMetadata) {
         let container = target.get_icon_container();
         container.set_status(status);
 
@@ -168,148 +197,19 @@ where
                     .icon_name(name.as_ref())
                     .build()
                     .upcast(),
-                IconSpec::Custom(factory) => factory(&metadata),
+                IconSpec::Custom(factory) => factory(metadata),
             };
 
             container.set_child(wdg);
         }
     }
-
-    async fn maybe_add_connect_button(
-        row: Option<&impl IsA<adw::ActionRow>>,
-        boxx: &gtk::Box,
-        server: &dyn ServerConnection,
-        path: &str,
-    ) {
-        let adapters = server.supported_adapters().await;
-
-        let connect_button = if adapters.len() == 1 {
-            let adapter = adapters.into_iter().next().unwrap();
-            Some(make_single_connect_button(path, adapter))
-        } else if !adapters.is_empty() {
-            Some(make_multi_connection_button(path, adapters))
-        } else {
-            None
-        };
-
-        if let Some(button) = connect_button {
-            if let Some(row) = row {
-                row.set_activatable_widget(Some(&button));
-            }
-            boxx.append(&button);
-        }
-    }
-
-    async fn maybe_add_edit_button(boxx: &gtk::Box, server: &dyn ServerConnection, path: &str) {
-        if server.editable() {
-            let label = gettext("Edit Server");
-            let button = gtk::Button::builder()
-                .action_name("app.edit-connection-server")
-                .action_target(&path.to_variant())
-                .icon_name("edit-symbolic")
-                .tooltip_text(&label)
-                .valign(gtk::Align::Center)
-                .css_classes(["flat"])
-                .build();
-            button.update_property(&[gtk::accessible::Property::Label(&label)]);
-
-            boxx.append(&button);
-        }
-    }
 }
 
 pub trait ServerInfoWidget {
+    fn window(&self) -> Option<FieldMonitorWindow>;
     fn set_server_title(&self, title: &str);
     fn set_server_subtitle(&self, subtitle: Option<&str>);
     fn get_icon_container(&self) -> ServerInfoIcon;
     fn get_actions_container(&self) -> adw::Bin;
     fn get_row(&self) -> Option<&impl IsA<adw::ActionRow>>;
-}
-
-pub async fn maybe_add_actions_button(
-    boxx: &gtk::Box,
-    server_or_connection: ServerOrConnection<'_>,
-    path: &str,
-) {
-    let (actions, is_server) = match server_or_connection {
-        ServerOrConnection::Server(server) => (server.actions().await, true),
-        ServerOrConnection::Connection(connection) => (connection.actions().await, false),
-    };
-
-    if actions.is_empty() {
-        return;
-    }
-    let menu = gio::Menu::new();
-    for (action_id, action_title) in actions {
-        let action_target = (is_server, path, &*action_id).to_variant();
-        menu.append(
-            Some(&*action_title),
-            Some(
-                gio::Action::print_detailed_name(
-                    "app.perform-connection-action",
-                    Some(&action_target),
-                )
-                .as_str(),
-            ),
-        );
-    }
-
-    let label = gettext("Actions");
-    let button = gtk::MenuButton::builder()
-        .menu_model(&menu)
-        .icon_name("view-more-symbolic")
-        .tooltip_text(&label)
-        .valign(gtk::Align::Center)
-        .css_classes(["flat"])
-        .build();
-    button.update_property(&[gtk::accessible::Property::Label(&label)]);
-
-    boxx.append(&button);
-}
-
-fn make_multi_connection_button(path: &str, adapters: Vec<(Cow<str>, Cow<str>)>) -> gtk::Widget {
-    let menu = gio::Menu::new();
-    for (adapter_id, adapter_label) in adapters {
-        let action_target = (path, &*adapter_id).to_variant();
-        menu.append(
-            Some(&*adapter_label),
-            Some(
-                gio::Action::print_detailed_name("app.connect-to-server", Some(&action_target))
-                    .as_str(),
-            ),
-        );
-    }
-
-    let label = gettext("Connect");
-    let button = gtk::MenuButton::builder()
-        .menu_model(&menu)
-        .icon_name("display-with-window-symbolic")
-        .tooltip_text(&label)
-        .valign(gtk::Align::Center)
-        .css_classes(["flat"])
-        .build();
-    button.update_property(&[gtk::accessible::Property::Label(&label)]);
-    button.upcast()
-}
-
-fn make_single_connect_button(
-    path: &str,
-    (adapter_id, adapter_label): (Cow<str>, Cow<str>),
-) -> gtk::Widget {
-    let label = gettext_f(
-        // Translators: Do NOT translate the content between '{' and '}', this is a
-        // variable name.
-        "Connect via {adapter}",
-        &[("adapter", &adapter_label)],
-    );
-    let button = gtk::Button::builder()
-        .action_name("app.connect-to-server")
-        .action_target(&(path, &*adapter_id).to_variant())
-        .icon_name("display-with-window-symbolic")
-        .tooltip_text(&label)
-        .valign(gtk::Align::Center)
-        .css_classes(["flat"])
-        .build();
-    button.update_property(&[gtk::accessible::Property::Label(&label)]);
-    button.upcast()
 }

--- a/src/widget/connection_list/server_info.rs
+++ b/src/widget/connection_list/server_info.rs
@@ -70,8 +70,7 @@ where
         Box::pin(async move {
             let window = target.window();
             if window
-                .as_ref()
-                .map(FieldMonitorWindow::is_connection_list_visible)
+                .map(|w| !w.is_connection_view_visible())
                 .unwrap_or_default()
             {
                 let metadata = server.metadata().await;

--- a/src/widget/connection_list/server_row.rs
+++ b/src/widget/connection_list/server_row.rs
@@ -18,6 +18,7 @@
 use crate::widget::connection_list::server_info::{
     ServerInfoIcon, ServerInfoUpdater, ServerInfoWidget,
 };
+use crate::widget::window::FieldMonitorWindow;
 use adw::prelude::*;
 use adw::subclass::prelude::*;
 use glib::WeakRef;
@@ -79,6 +80,10 @@ impl FieldMonitorServerRow {
 }
 
 impl ServerInfoWidget for FieldMonitorServerRow {
+    fn window(&self) -> Option<FieldMonitorWindow> {
+        self.root().and_downcast()
+    }
+
     fn set_server_title(&self, title: &str) {
         self.set_title(&glib::markup_escape_text(title))
     }

--- a/src/widget/window.rs
+++ b/src/widget/window.rs
@@ -272,8 +272,8 @@ impl FieldMonitorWindow {
         let child = self.imp().current_server_screen_bin.child();
         child.and_downcast()
     }
-    pub fn is_connection_list_visible(&self) -> bool {
-        self.imp().app_mode_stack.visible_child_name().as_deref() == Some("connection-list")
+    pub fn is_connection_view_visible(&self) -> bool {
+        self.imp().app_mode_stack.visible_child_name().as_deref() == Some("connection-view")
     }
 
     /// Try to focus an already open connection view, if a connection view for the given

--- a/src/widget/window.rs
+++ b/src/widget/window.rs
@@ -272,6 +272,9 @@ impl FieldMonitorWindow {
         let child = self.imp().current_server_screen_bin.child();
         child.and_downcast()
     }
+    pub fn is_connection_list_visible(&self) -> bool {
+        self.imp().app_mode_stack.visible_child_name().as_deref() == Some("connection-list")
+    }
 
     /// Try to focus an already open connection view, if a connection view for the given
     /// server is open


### PR DESCRIPTION
This fixes,
- the app hanging when running for a few hours
  - the buttons were recreated every 15 seconds, even when the connection view was open. This was incredibly inefficient and also seems to have surfaced a GTK bug where some internal state concerning the actions doesn't get cleaned up, leading new action buttons creation to take an exponential amount of time
- that the caching mechanism for server metadata wasn't actually working correctly (always fetched free content BEFORE cache expiration and stale content afterwards; condition was flipped)

TODO:
- [x] Needs to be based on #157 (should be merged first)
- [x] Sometimes entries "lag" and have no title or subtitle for quite some time: investigate (been noticing this with Proxmox)